### PR TITLE
Fix CRF validation bug

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -177,7 +177,11 @@ def register_routes(app):
         """
         data = request.get_json()
         src = data.get("src")
-        crf = int(data.get("crf", 28))
+        crf_value = data.get("crf", 28)
+        try:
+            crf = int(crf_value)
+        except (TypeError, ValueError):
+            return ApiResponse.fail("Invalid crf"), 400
         if not src:
             return ApiResponse.fail("Missing src"), 400
         out_path = src.replace(".mp4", "_compressed.mp4")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,20 @@
+import pytest
+from flask import Flask
+from app.routes import register_routes
+
+
+def create_app():
+    app = Flask(__name__)
+    register_routes(app)
+    return app
+
+
+def test_compress_invalid_crf():
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.post('/compress', json={'src': 'file.mp4', 'crf': 'abc'})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data['status'] == 'fail'
+        assert 'Invalid crf' in data['message']
+


### PR DESCRIPTION
## Summary
- validate CRF input when compressing videos
- add regression test for invalid CRF values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3bedc084832c86fc61dc7f39445c